### PR TITLE
Define property to configure docker plugins buffer_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The supported variables are:
  FLB_FORWARD_BUF_CHUNK_SIZE    | Allocation block size used by `forward` input plugin                                           | 1M
  FLB_FORWARD_BUF_MAX_SIZE      | Memory limit for a message received by `forward` input plugin                                  | 3M
  FLB_STORAGE_BACKLOG_MEM_LIMIT | Memory limit for backlog (unprocessed data) processing                                         | 10M
+ FLB_DOCKER_IN_BUF_SIZE        | Size of the buffer used by Docker plugins to fetch data (in bytes or [unit sized](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/unit-sizes))                                                                                                                   | 30K
  FLB_HOST_NET_INTERFACE        | Name of the host network interface to monitor                                                  | eth0
  FLB_COLLECT_CONTAINER_LABELS  | Enable Docker container labels collection                                                      | false
 

--- a/code/fluent-beats/entrypoint.sh
+++ b/code/fluent-beats/entrypoint.sh
@@ -45,6 +45,9 @@ fi
 if [[ ! -n "${FLB_COLLECT_CONTAINER_LABELS}" ]]; then
   export FLB_COLLECT_CONTAINER_LABELS=false
 fi
+if [[ ! -n "${FLB_DOCKER_IN_BUF_SIZE}" ]]; then
+  export FLB_DOCKER_IN_BUF_SIZE=30K
+fi
 
 # setup_agent
 export AGENT_ID=$(echo $RANDOM | md5sum | head -c 12)

--- a/code/fluent-beats/pipelines/docker-info/pipeline-info.conf
+++ b/code/fluent-beats/pipelines/docker-info/pipeline-info.conf
@@ -6,7 +6,7 @@
     key                     docker
     parser                  docker_message
     collect_interval        ${FLB_DOCKER_METRICS_INTERVAL}
-    buffer_size             12K
+    buffer_size             ${FLB_DOCKER_IN_BUF_SIZE}
     mem_buf_limit           ${FLB_MEM_BUF_LIMIT}
     storage.type            filesystem
 

--- a/code/fluent-beats/pipelines/docker-stats/pipeline-stats.conf
+++ b/code/fluent-beats/pipelines/docker-stats/pipeline-stats.conf
@@ -6,7 +6,7 @@
     key                     docker
     parser                  docker_message
     collect_interval        ${FLB_DOCKER_METRICS_INTERVAL}
-    buffer_size             8K
+    buffer_size             ${FLB_DOCKER_IN_BUF_SIZE}
     mem_buf_limit           ${FLB_MEM_BUF_LIMIT}
     storage.type            filesystem
 

--- a/code/fluent-beats/pipelines/docker-system/pipeline-system.conf
+++ b/code/fluent-beats/pipelines/docker-system/pipeline-system.conf
@@ -6,7 +6,7 @@
     key                     docker
     parser                  docker_message
     collect_interval        ${FLB_DOCKER_METRICS_INTERVAL}
-    buffer_size             8K
+    buffer_size             ${FLB_DOCKER_IN_BUF_SIZE}
     mem_buf_limit           ${FLB_MEM_BUF_LIMIT}
     storage.type            filesystem
 


### PR DESCRIPTION
Added new configuration property `FLB_DOCKER_IN_BUF_SIZE`.

## Details

1. This property allows configuration of `buffer_size` used by the following plugins:
    - docker-info
    - docker-stats
    - docker-system

2. The container entry point script will set property to default value (30KB) if not defined on environment config file. 