### PR TITLE
Define plugin alias to improve monitoring

### DIFF
--- a/code/fluent-beats/pipelines/apm/pipeline-apm.conf
+++ b/code/fluent-beats/pipelines/apm/pipeline-apm.conf
@@ -2,6 +2,7 @@
 
 [INPUT]
     name                    carbon
+    alias                   apm_input
     listen                  0.0.0.0
     port                    8125
     tag                     apm
@@ -10,6 +11,7 @@
 
 [FILTER]
     name                    lua
+    alias                   apm_lua_filter
     match                   apm
     script                  apm-ecs.lua
     call                    carbon_to_ecs
@@ -17,6 +19,7 @@
 # Elasticsearch -> Index template 'metrics'
 [OUTPUT]
     name                    es
+    alias                   apm_es_output
     match                   apm
     index                   metrics-apm.stats-default
     suppress_type_name      on

--- a/code/fluent-beats/pipelines/docker-info/pipeline-info.conf
+++ b/code/fluent-beats/pipelines/docker-info/pipeline-info.conf
@@ -2,6 +2,7 @@
 
 [INPUT]
     name                    docker_info
+    alias                   info_docker_input
     tag                     info
     key                     docker
     parser                  docker_message
@@ -12,6 +13,7 @@
 
 [FILTER]
     name                    lua
+    alias                   info_docker_lua_filter
     match                   info
     script                  info-ecs.lua
     call                    docker_info_to_ecs
@@ -19,20 +21,23 @@
 # Route metrics to 'metrics-docker.info-default'
 [FILTER]
     name                    rewrite_tag
+    alias                   info_metrics_docker_tag_filter
     match                   info
     rule                    $data_stream['type'] ^(metrics)$ info_metrics true
-    emitter_name            emit_info_metrics
+    emitter_name            info_metrics_docker_emiter
 
 # Route uptime to 'metrics-docker.info-default'
 [FILTER]
     name                    rewrite_tag
+    alias                   info_uptime_docker_tag_filter
     match                   info
     rule                    $monitor['type'] ^(tcp)$ info_uptime false
-    emitter_name            emit_info_uptime
+    emitter_name            info_uptime_docker_emitter
 
 # Elasticsearch -> Index template 'metrics'
 [OUTPUT]
     name                    es
+    alias                   info_metrics_docker_es_output
     match                   info_metrics
     index                   metrics-docker.info-default
     suppress_type_name      on
@@ -49,6 +54,7 @@
 # Elasticsearch -> Index template 'heartbeat-8-default'
 [OUTPUT]
     name                    es
+    alias                   info_uptime_docker_es_output
     match                   info_uptime
     index                   heartbeat-8-default
     suppress_type_name      on

--- a/code/fluent-beats/pipelines/docker-logs/pipeline-logs.conf
+++ b/code/fluent-beats/pipelines/docker-logs/pipeline-logs.conf
@@ -2,6 +2,7 @@
 
 [INPUT]
     name                    forward
+    alias                   logs_docker_input
     tag                     logs
     listen                  0.0.0.0
     port                    24224
@@ -16,6 +17,7 @@
 #   java   -> flb_ml_parser_java.c
 [FILTER]
     name                    multiline
+    alias                   logs_docker_multiline_filter
     match                   logs
     multiline.key_content   log
     multiline.parser        docker,java
@@ -23,6 +25,7 @@
 # From Microservices perspective logs should be JSON
 [FILTER]
     name                    parser
+    alias                   logs_docker_parser_filter
     match                   logs
     parser                  docker_log
     key_name                log
@@ -30,6 +33,7 @@
 
 [FILTER]
     name                    lua
+    alias                   logs_docker_lua_filter
     match                   logs
     script                  logs-ecs.lua
     call                    fluentd_to_ecs
@@ -37,6 +41,7 @@
 # Elasticsearch -> Index template 'logs'
 [OUTPUT]
     name                    es
+    alias                   logs_docker_es_output
     match                   logs
     index                   logs-docker.logs-default
     suppress_type_name      on

--- a/code/fluent-beats/pipelines/docker-stats/pipeline-stats.conf
+++ b/code/fluent-beats/pipelines/docker-stats/pipeline-stats.conf
@@ -2,6 +2,7 @@
 
 [INPUT]
     name                    docker_stats
+    alias                   stats_docker_input
     tag                     stats
     key                     docker
     parser                  docker_message
@@ -12,6 +13,7 @@
 
 [FILTER]
     name                    lua
+    alias                   stats_docker_lua_filter
     match                   stats
     script                  stats-ecs.lua
     call                    docker_stats_to_ecs
@@ -19,6 +21,7 @@
 # Elasticsearch -> Index template 'metrics'
 [OUTPUT]
     name                    es
+    alias                   stats_docker_es_output
     match                   stats
     index                   metrics-docker.stats-default
     suppress_type_name      on

--- a/code/fluent-beats/pipelines/docker-system/pipeline-system.conf
+++ b/code/fluent-beats/pipelines/docker-system/pipeline-system.conf
@@ -2,6 +2,7 @@
 
 [INPUT]
     name                    docker_system
+    alias                   system_docker_input
     tag                     system
     key                     docker
     parser                  docker_message
@@ -12,6 +13,7 @@
 
 [FILTER]
     name                    lua
+    alias                   system_docker_lua_filter
     match                   system
     script                  system-ecs.lua
     call                    docker_system_to_ecs
@@ -19,6 +21,7 @@
 # Elasticsearch -> Index template 'metrics'
 [OUTPUT]
     name                    es
+    alias                   system_docker_es_output
     match                   system
     index                   metrics-docker.system-default
     suppress_type_name      on

--- a/code/fluent-beats/pipelines/host/pipeline-host.conf
+++ b/code/fluent-beats/pipelines/host/pipeline-host.conf
@@ -3,6 +3,7 @@
 [INPUT]
     # requires container bind to host /proc/stat
     name                    cpuinfo
+    alias                   host_cpu_input
     tag                     host_cpu
     proc_path               /hostfs/proc
     interval_sec            ${FLB_HOST_METRICS_INTERVAL}
@@ -11,6 +12,7 @@
 [INPUT]
     # requires container bind to host /proc/stat
     name                    diskinfo
+    alias                   host_disk_input
     tag                     host_disk
     proc_path               /hostfs/proc
     interval_sec            ${FLB_HOST_METRICS_INTERVAL}
@@ -19,6 +21,7 @@
 [INPUT]
     # requires container bind to host /proc/stat
     name                    meminfo
+    alias                   host_memory_input
     tag                     host_memory
     proc_path               /hostfs/proc
     interval_sec            ${FLB_HOST_METRICS_INTERVAL}
@@ -27,6 +30,7 @@
 [INPUT]
     # requires container bind to host /proc/stat
     name                    netinfo
+    alias                   host_netif_input
     tag                     host_netif
     proc_path               /hostfs/proc
     interface               ${FLB_HOST_NET_INTERFACE}
@@ -36,6 +40,7 @@
 [INPUT]
     # requires container bind to host /proc/stat
     name                    load
+    alias                   host_load_input
     tag                     host_load
     proc_path               /hostfs/proc
     interval_sec            ${FLB_HOST_METRICS_INTERVAL}
@@ -43,6 +48,7 @@
 
 [INPUT]
     name                    fsinfo
+    alias                   host_fs_input
     tag                     host_fs
     mount_point             /
     interval_sec            ${FLB_HOST_METRICS_INTERVAL}
@@ -50,6 +56,7 @@
 
 [FILTER]
     name                    lua
+    alias                   host_lua_filter
     match                   host_*
     script                  host-ecs.lua
     call                    host_metric_to_ecs
@@ -57,6 +64,7 @@
 # Elasticsearch -> Data stream 'metrics'
 [OUTPUT]
     name                    es
+    alias                   host_es_output
     match                   host_*
     index                   metrics-host.stats-default
     suppress_type_name      on


### PR DESCRIPTION
Aliased to each  `fluentbit` plugin used by `fluent-beats` pipelines. 

This improves monitoring experience, because by default the monitoring endpoints identify plugins using the pattern `plugin_name.ID`

[Reference](https://docs.fluentbit.io/manual/v/1.8/administration/monitoring#configuring-aliases)