### PR TITLE
Adjust host metrics module name

### DIFF
--- a/code/fluent-beats/pipelines/host/host-ecs.lua
+++ b/code/fluent-beats/pipelines/host/host-ecs.lua
@@ -1,6 +1,6 @@
 -- Translates Host Metrics to Elastic ECS Event
 
-MODULE_NAME = 'host'
+MODULE_NAME = 'system'
 ECS_VERSION = "8.0.0"
 AGENT_NAME = 'fluent-beats'
 AGENT_ID = os.getenv('AGENT_ID')


### PR DESCRIPTION
# Context

## Versions
- Fluent-Beats : `1.1.0`
- Elasticsearch:  `8.17.0` 

## Description
No data show on  Hosts interface 
- **Observability > Insfastructure > Hosts**

## Cause
A change on Elasticsearch ECS mapping for host metrics, has affected Fluent-Beats hosts pipeline.

These metrics were usually identified under the module `host`, but now the module has changed to `system`

## Evidences

1. Change the pipeline to send only `host_load` to the data stream `metrics-system.load-default` and enable `trace_error`

``` yaml
[OUTPUT]
    name es
    alias host_es_output
    match host_load
    index metrics-system.load-default
    suppress_type_name on
    tls on
    tls.verify off
    trace_error on
    host ${FLB_ES_HTTP_HOST}
    port 9243
    http_user elastic
    http_passwd  ${FLB_ES_HTTP_PASSWD}
    retry_limit 5
    workers 1
```
Elasticsearch API returns a 400 error related with wrong field value:

![image](https://github.com/user-attachments/assets/0c1a827e-60d3-4998-a2e3-ed6d07f2ae94)

2.  Double check index template using Kibana
- **Management > Data > Index Management > Component Templates > metrics-system.load@package**

![change](https://github.com/user-attachments/assets/8f1cd026-41ca-4024-88eb-00ae56ba69d9)